### PR TITLE
Does not try to wrap getters & setters

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function _actualMethodKeys(target) {
   return Object.getOwnPropertyNames(target)
     .filter(key => {
       var propertyDescriptor = Object.getOwnPropertyDescriptor(target, key);
-      return propertyDescriptor.get == null && propertyDescriptor.set == null;
+      return !propertyDescriptor.get && !propertyDescriptor.set;
     })
     .filter(key => typeof target[key] === 'function');
 }

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function validateMethodNames(methodNames) {
 }
 
 function wrapFunctions(target, methodNames) {
-  Object.getOwnPropertyNames(target).forEach(function(key) {
+  _actualMethodKeys(target).forEach(function(key) {
     let constructor = target[key].constructor.name;
 
     if (methodNames) {
@@ -78,14 +78,21 @@ function wrapFunctions(target, methodNames) {
       return;
     }
 
-    if (typeof target[key] !== 'function') return;
-
     if (target[key].constructor.name === 'GeneratorFunction') {
       target[key] = Promise.coroutine(target[key]);
     } else {
       target[key] = Promise.method(target[key]);
     }
   });
+}
+
+function _actualMethodKeys(target) {
+  return Object.getOwnPropertyNames(target)
+    .filter(key => {
+      var propertyDescriptor = Object.getOwnPropertyDescriptor(target, key);
+      return propertyDescriptor.get == null && propertyDescriptor.set == null;
+    })
+    .filter(key => typeof target[key] === 'function');
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -33,6 +33,10 @@ class FakeDataStore {
     return keys;
   }
 
+  get size() {
+    return this.store.size;
+  }
+
   getAsync(key) {
     let val = this.store.get(key);
     return Promise.resolve(val);
@@ -54,8 +58,12 @@ describe('async-class', function() {
   });
 
   describe('wrap', function() {
+    it('does not modify getters', function() {
+      expect(dataStore.size).to.eql(0);
+    });
+
     it('only modifies properties that are functions', function() {
-      expect(dataStore.store).to.be.instanceOf(Map)
+      expect(dataStore.store).to.be.instanceOf(Map);
     });
 
     it('does not wrap functions that do not end with Async', function() {


### PR DESCRIPTION
There was an issue with property accessors. There was an error when doing:

``` js
class A {
  get valueGetter() { return this.value }
}
```

That was because `valueGetter` property was called on the class prototype, which did not have any `value` defined. ([at this line](https://github.com/danielstjules/async-class/blob/master/index.js#L73))

So I've filtered out getters and setters from the checked keys.
